### PR TITLE
Regtest integration

### DIFF
--- a/app/master/sync/sync.js
+++ b/app/master/sync/sync.js
@@ -3,7 +3,7 @@
 var _ = require('lodash')
 var EventEmitter = require('events').EventEmitter
 var inherits = require('util').inherits
-var bitcore = require('bitcore')
+var bitcore = require('../../../lib/patchedbitcore')
 var Promise = require('bluebird')
 
 var config = require('../../../lib/config')

--- a/app/slave/http/controllers/transactions.js
+++ b/app/slave/http/controllers/transactions.js
@@ -1,7 +1,7 @@
 /* globals Promise:true */
 
 var _ = require('lodash')
-var bitcore = require('bitcore')
+var bitcore = require('../../../../lib/patchedbitcore')
 var bufferEqual = require('buffer-equal')
 var Promise = require('bluebird')
 

--- a/app/slave/http/util/query.js
+++ b/app/slave/http/util/query.js
@@ -2,7 +2,7 @@
 
 var _ = require('lodash')
 var assert = require('assert')
-var bitcore = require('bitcore')
+var bitcore = require('../../../../lib/patchedbitcore')
 var Address = bitcore.Address
 var isHexa = bitcore.util.js.isHexa
 

--- a/app/slave/master.js
+++ b/app/slave/master.js
@@ -1,7 +1,7 @@
 /* globals Promise:true */
 
 var _ = require('lodash')
-var bitcore = require('bitcore')
+var bitcore = require('../../lib/patchedbitcore')
 var Promise = require('bluebird')
 
 var EventEmitter = require('events').EventEmitter

--- a/app/slave/ws/index.js
+++ b/app/slave/ws/index.js
@@ -1,7 +1,8 @@
 /* globals Promise:true */
 
 var io = require('socket.io')
-var Address = require('bitcore').Address
+var Address = require('../../../lib/patchedbitcore').Address
+
 var Promise = require('bluebird')
 
 var config = require('../../../lib/config')

--- a/config/master.yml
+++ b/config/master.yml
@@ -1,5 +1,6 @@
 chromanode:
   network: testnet # livenet | testnet
+  testnetwork: regtest # testnet | regtest
   sync:
     maxCachedBlocks: 2 # useful for remote bitcoind
 

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -31,7 +31,7 @@ module.exports = errorSystem.extend(Error, {
   message: 'Chromanode internal error',
   errors: [{
     name: 'InvalidBitcoindNetwork',
-    message: 'Bitcoind have other network!'
+    message: 'Bitcoind have other network! Got {0} expected {1}'
   }, {
     name: 'InvalidNetwork',
     message: 'Invalid network: {0}'

--- a/lib/patchedbitcore.js
+++ b/lib/patchedbitcore.js
@@ -1,0 +1,15 @@
+var bitcore = require('bitcore')
+bitcore.Networks.add({
+  name: 'regtest',
+  alias: 'regtest',
+  pubkeyhash: 0x6f,
+  privatekey: 0xef,
+  scripthash: 0xc4,
+  xpubkey: 0x043587cf,
+  xprivkey: 0x04358394,
+  networkMagic: 0xFABFB5DA,
+  port: 8333,
+  dnsSeeds: [ ]
+})
+
+module.exports = bitcore

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,7 +1,7 @@
 /* globals Promise:true */
 
 var _ = require('lodash')
-var bitcore = require('bitcore')
+var bitcore = require('./patchedbitcore')
 var Promise = require('bluebird')
 
 var errors = require('./errors')
@@ -14,6 +14,19 @@ function checkNetwork (name) {
   if (bitcore.Networks.get(name) === undefined) {
     throw new errors.InvalidNetwork(name)
   }
+}
+
+/**
+ * @param {object} config
+ * @return {string}
+ */
+function getNetworkName (config) {
+  // check for regtest mode if testnet
+  var networkName = config.get('chromanode.network')
+  if (networkName == 'testnet') {
+    networkName = config.get('chromanode.testnetwork')
+  }
+  return networkName
 }
 
 /**
@@ -125,6 +138,7 @@ module.exports = {
   ZERO_HASH: '0000000000000000000000000000000000000000000000000000000000000000',
 
   checkNetwork: checkNetwork,
+  getNetworkName: getNetworkName,
   getVersion: getVersion,
   decode: decode,
   encode: encode,


### PR DESCRIPTION
Making it possible to run chromanode in regtest mode. Routing all
imports of bitcore through a patch that adds regtest support, see
https://github.com/bitpay/bitcore/issues/1190
Adding a sub-config option to testnet called regtest that sets the
server in regtest mode if both testnet is selected and regtest is
selected in the config file.